### PR TITLE
add tickets blocck and config parser

### DIFF
--- a/examples/scripts/embed.py
+++ b/examples/scripts/embed.py
@@ -1,11 +1,12 @@
-from cx_copilot import OpenAIEmbeddingBlock, PineconeVectorDBBlock, GPTCompletionBlock, RedisCache
+from cx_copilot import OpenAIEmbeddingBlock, PineconeVectorDBBlock, GPTCompletionBlock, RedisCache, CXCopilot
 
-op = OpenAIEmbeddingBlock(open_ai_key='YOUR_OPEN_AI_KEY')
-vec = op.embed_text('hello, please help me reset my account password')
-db = PineconeVectorDBBlock("YOUR_PINECONE_KEY", "us-west1-gcp")
-completion = GPTCompletionBlock(open_ai_key = 'YOUR_OPEN_AI_KEY')
-cache = RedisCache(host='localhost', port=6379, db=0)
-print(db.lookup(vec, 'YOUR_PINECONE_INDEX').ClosestEmbeddings)
-print(completion.get_completion("What year was San Francisco established?", 2000, 0))
-print(cache.put('test', 'result'))
-print(cache.get('test'))
+# op = OpenAIEmbeddingBlock(open_ai_key='YOUR_OPEN_AI_KEY')
+# vec = op.embed_text('hello, please help me reset my account password')
+# db = PineconeVectorDBBlock("YOUR_PINECONE_KEY", "us-west1-gcp")
+# completion = GPTCompletionBlock(open_ai_key = 'YOUR_OPEN_AI_KEY')
+# cache = RedisCache(host='localhost', port=6379, db=0)
+# print(db.lookup(vec, 'YOUR_PINECONE_INDEX').ClosestEmbeddings)
+# print(completion.get_completion("What year was San Francisco established?", 2000, 0))
+# print(cache.put('test', 'result'))
+# print(cache.get('test'))
+print(CXCopilot().cache_block.get('test'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ dependencies=[
     "requests~=2.28.1",
     "pinecone-client==2.1.0",
     "redis~=4.4.1",
-    "openai~=0.26.0"
+    "openai~=0.26.0",
+    "python-helpscout-v2==2.0.0",
+    "envyaml~=1.10.211231"
 ]
 
 [project.optional-dependencies]

--- a/src/cx_copilot/__init__.py
+++ b/src/cx_copilot/__init__.py
@@ -4,6 +4,7 @@ from .blocks.embedding import OpenAIEmbeddingBlock
 from .blocks.vectordb import PineconeVectorDBBlock
 from .blocks.completion import GPTCompletionBlock
 from .blocks.cache import RedisCache
+from .compound.compound import CXCopilot
 __version__ = "0.0.2"
 
 

--- a/src/cx_copilot/blocks/tickets.py
+++ b/src/cx_copilot/blocks/tickets.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import List, Dict
+from helpscout import HelpScout
+
+
+class Thread:
+    body: str
+
+    def __init__(self, body: str):
+        self.body = body
+
+
+class Conversation:
+    threads: List[Thread]
+
+    def __init__(self, threads: List[Thread]):
+        self.threads = threads
+
+
+class ConversationRepository:
+    def get_conversation_by_id(self, conversation_id: str) -> Conversation | None:
+        raise NotImplementedError
+
+
+def _helpscout_thread_to_common(thread: Dict) -> Thread:
+    return Thread(body=thread['body'])
+
+
+class HelpscoutConversationRepository(ConversationRepository):
+    helpscout: HelpScout
+
+    def __init__(self, app_id: str, app_secret: str):
+        self.helpscout = HelpScout(app_id=app_id, app_secret=app_secret)
+
+    def get_conversation_by_id(self, conversation_id: str) -> Conversation | None:
+        threads = self.helpscout.conversations[conversation_id].threads.get()
+        mapped = map(_helpscout_thread_to_common, threads)
+        return Conversation(threads=mapped)

--- a/src/cx_copilot/compound/compound.py
+++ b/src/cx_copilot/compound/compound.py
@@ -1,0 +1,25 @@
+from typing import Optional, Dict
+import redis
+from envyaml import EnvYAML
+from ..blocks.cache import Cache, RedisCache
+from ..blocks.tickets import ConversationRepository
+
+
+class CXCopilot:
+    cache_block: Cache
+    ticket_repo: ConversationRepository
+
+    def __init_cache__(self, yaml: EnvYAML):
+        cache_config: Optional[Dict] = yaml.get('cache')
+        if cache_config is None:
+            return
+
+        if cache_config['type'] == 'redis':
+            host = cache_config['host']
+            port = cache_config['port']
+            db = cache_config['db']
+            self.cache_block = RedisCache(host=host, port=port, db=db)
+
+    def __init__(self, path='copilot_config.yml'):
+        env = EnvYAML(path)
+        self.__init_cache__(env)


### PR DESCRIPTION
This PR adds the following functionality:

(1): It adds the tickets block which will help with fetching tickets from your ticketing system at runtime
(2): It adds config parser with defaults:

The flow would be this - CXCopilot is going to be provider, cache, embeddings etc. agnostic. We are only going to use abstract classes to define all providers. 

You can define what providers you are going to use in your copilot_config.yml and it will automatically use that type of class. So if you define Redis credentials in your config file, we will instantiate the cache block with redis instance. The interface for cache will remain the same regardless. 


